### PR TITLE
ScreeshotPathを編集しセーブするとクラッシュする

### DIFF
--- a/AndroidRecorder/ApplicationConfig.cs
+++ b/AndroidRecorder/ApplicationConfig.cs
@@ -54,6 +54,7 @@ namespace AndroidRecorder
                 this.saveDir = saveDir;
                 this.recordingTime = recordingTime;
                 this.pullWaitTime = pullWaitTime;
+                this.saveImageDir = saveImageDir;
             }
         }
 


### PR DESCRIPTION
値引き渡し時に値を格納できてなかったことが原因